### PR TITLE
Contribute Direct Processes

### DIFF
--- a/executable/build.go
+++ b/executable/build.go
@@ -64,9 +64,24 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 	command := "java"
 	arguments := []string{mc}
 	result.Processes = append(result.Processes,
-		libcnb.Process{Type: "executable-jar", Command: command, Arguments: arguments},
-		libcnb.Process{Type: "task", Command: command, Arguments: arguments},
-		libcnb.Process{Type: "web", Command: command, Arguments: arguments},
+		libcnb.Process{
+			Type:      "executable-jar",
+			Command:   command,
+			Arguments: arguments,
+			Direct:    true,
+		},
+		libcnb.Process{
+			Type:      "task",
+			Command:   command,
+			Arguments: arguments,
+			Direct:    true,
+		},
+		libcnb.Process{
+			Type:      "web",
+			Command:   command,
+			Arguments: arguments,
+			Direct:    true,
+		},
 	)
 
 	cp := []string{context.Application.Path}

--- a/executable/build_test.go
+++ b/executable/build_test.go
@@ -65,9 +65,24 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 			Expect(result.Layers[0].(executable.ClassPath).ClassPath).To(Equal([]string{ctx.Application.Path, "test-class-path"}))
 			Expect(result.Processes).To(ContainElements(
-				libcnb.Process{Type: "executable-jar", Command: "java", Arguments: []string{"test-main-class"}},
-				libcnb.Process{Type: "task", Command: "java", Arguments: []string{"test-main-class"}},
-				libcnb.Process{Type: "web", Command: "java", Arguments: []string{"test-main-class"}},
+				libcnb.Process{
+					Type:      "executable-jar",
+					Command:   "java",
+					Arguments: []string{"test-main-class"},
+					Direct:    true,
+				},
+				libcnb.Process{
+					Type:      "task",
+					Command:   "java",
+					Arguments: []string{"test-main-class"},
+					Direct:    true,
+				},
+				libcnb.Process{
+					Type:      "web",
+					Command:   "java",
+					Arguments: []string{"test-main-class"},
+					Direct:    true,
+				},
 			))
 		})
 
@@ -84,9 +99,24 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 			Expect(result.Layers[0].(executable.ClassPath).ClassPath).To(Equal([]string{ctx.Application.Path}))
 			Expect(result.Processes).To(ContainElements(
-				libcnb.Process{Type: "executable-jar", Command: "java", Arguments: []string{"test-main-class"}},
-				libcnb.Process{Type: "task", Command: "java", Arguments: []string{"test-main-class"}},
-				libcnb.Process{Type: "web", Command: "java", Arguments: []string{"test-main-class"}},
+				libcnb.Process{
+					Type:      "executable-jar",
+					Command:   "java",
+					Arguments: []string{"test-main-class"},
+					Direct:    true,
+				},
+				libcnb.Process{
+					Type:      "task",
+					Command:   "java",
+					Arguments: []string{"test-main-class"},
+					Direct:    true,
+				},
+				libcnb.Process{
+					Type:      "web",
+					Command:   "java",
+					Arguments: []string{"test-main-class"},
+					Direct:    true,
+				},
 			))
 		})
 


### PR DESCRIPTION
Now that exec.d is support in buildpack API 0.5 and the profile scripts have been replaced with executables, a shell
is no longer need to launch executable JAR processes. Therefore we can switch to direct process types for faster startup
times and more intuitive argument handling

Signed-off-by: Emily Casey <ecasey@vmware.com>