### PR TITLE
Require jvm-application-package in build plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,21 @@
 The Paketo Executable JAR Buildpack is a Cloud Native Buildpack that contributes a Process Type for executable JARs.
 
 ## Behavior
-This buildpack will participate if all the following conditions are met
+This buildpack will participate if all the following conditions are met:
 
 * `<APPLICATION_ROOT>/META-INF/MANIFEST.MF` contains a `Main-Class` entry
 
-The buildpack will do the following:
-
+When building a JVM application the buildpack will do the following:
 * Requests that a JRE be installed
-* Contributes `<APPLICATION_ROOT>` to `$CLASSPATH`
+* Contributes `<APPLICATION_ROOT>` to build and runtime `$CLASSPATH`
 * If `<APPLICATION_ROOT>/META-INF/MANIFEST.MF` `Class-Path` exists
-  * Contributes entries to `$CLASSPATH`
+  * Contributes entries to build and runtime `$CLASSPATH`
 * Contributes `executable-jar`, `task`, and `web` process types
+
+When participating in the build of a native image application the buildpack will:
+* Contributes `<APPLICATION_ROOT>` to build-time `$CLASSPATH`
+* If `<APPLICATION_ROOT>/META-INF/MANIFEST.MF` `Class-Path` exists
+  * Contributes entries to build-time `$CLASSPATH`
 
 ## License
 This buildpack is released under version 2.0 of the [Apache License][a].

--- a/executable/detect.go
+++ b/executable/detect.go
@@ -23,6 +23,12 @@ import (
 	"github.com/paketo-buildpacks/libjvm"
 )
 
+const (
+	PlanEntryJVMApplication        = "jvm-application"
+	PlanEntryJVMApplicationPackage = "jvm-application-package"
+	PlanEntryJRE                   = "jre"
+)
+
 type Detect struct{}
 
 func (d Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error) {
@@ -30,9 +36,13 @@ func (d Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error
 		Pass: true,
 		Plans: []libcnb.BuildPlan{
 			{
+				Provides: []libcnb.BuildPlanProvide{
+					{Name: PlanEntryJVMApplication},
+				},
 				Requires: []libcnb.BuildPlanRequire{
-					{Name: "jre", Metadata: map[string]interface{}{"launch": true}},
-					{Name: "jvm-application"},
+					{Name: PlanEntryJRE, Metadata: map[string]interface{}{"launch": true}},
+					{Name: PlanEntryJVMApplicationPackage},
+					{Name: PlanEntryJVMApplication},
 				},
 			},
 		},
@@ -44,7 +54,7 @@ func (d Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error
 	}
 
 	if _, ok := m.Get("Main-Class"); ok {
-		result.Plans[0].Provides = append(result.Plans[0].Provides, libcnb.BuildPlanProvide{Name: "jvm-application"})
+		result.Plans[0].Provides = append(result.Plans[0].Provides, libcnb.BuildPlanProvide{Name: PlanEntryJVMApplicationPackage})
 	}
 
 	return result, nil

--- a/executable/detect_test.go
+++ b/executable/detect_test.go
@@ -50,54 +50,82 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 		Expect(os.RemoveAll(path)).To(Succeed())
 	})
 
-	it("passes without META-INF/MANIFEST.MF", func() {
-		Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{
-			Pass: true,
-			Plans: []libcnb.BuildPlan{
-				{
-					Requires: []libcnb.BuildPlanRequire{
-						{Name: "jre", Metadata: map[string]interface{}{"launch": true}},
-						{Name: "jvm-application"},
+	context("META-INF/MANIFEST.MF not found", func() {
+		it("requires jvm-application-package", func() {
+			Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{
+				Pass: true,
+				Plans: []libcnb.BuildPlan{
+					{
+						Provides: []libcnb.BuildPlanProvide{
+							{Name: "jvm-application"},
+						},
+						Requires: []libcnb.BuildPlanRequire{
+							{Name: "jre", Metadata: map[string]interface{}{"launch": true}},
+							{Name: "jvm-application-package"},
+							{Name: "jvm-application"},
+						},
 					},
 				},
-			},
-		}))
+			}))
+		})
 	})
 
-	it("passes with empty META-INF/MANIFEST.MF", func() {
-		Expect(os.MkdirAll(filepath.Join(path, "META-INF"), 0755)).To(Succeed())
-		Expect(ioutil.WriteFile(filepath.Join(path, "META-INF", "MANIFEST.MF"), []byte(""), 0644))
+	context("empty META-INF/MANIFEST.MF not found", func() {
+		it.Before(func() {
+			Expect(os.MkdirAll(filepath.Join(path, "META-INF"), 0755)).To(Succeed())
+			Expect(ioutil.WriteFile(
+				filepath.Join(path, "META-INF", "MANIFEST.MF"),
+				[]byte(""),
+				0644,
+			)).To(Succeed())
+		})
 
-		Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{
-			Pass: true,
-			Plans: []libcnb.BuildPlan{
-				{
-					Requires: []libcnb.BuildPlanRequire{
-						{Name: "jre", Metadata: map[string]interface{}{"launch": true}},
-						{Name: "jvm-application"},
+		it("requires jvm-application-package", func() {
+			Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{
+				Pass: true,
+				Plans: []libcnb.BuildPlan{
+					{
+						Provides: []libcnb.BuildPlanProvide{
+							{Name: "jvm-application"},
+						},
+						Requires: []libcnb.BuildPlanRequire{
+							{Name: "jre", Metadata: map[string]interface{}{"launch": true}},
+							{Name: "jvm-application-package"},
+							{Name: "jvm-application"},
+						},
 					},
 				},
-			},
-		}))
+			}))
+		})
 	})
 
-	it("passes with Main-Class", func() {
-		Expect(os.MkdirAll(filepath.Join(path, "META-INF"), 0755)).To(Succeed())
-		Expect(ioutil.WriteFile(filepath.Join(path, "META-INF", "MANIFEST.MF"), []byte("Main-Class: test-main-class"), 0644))
+	context("META-INF/MANIFEST.MF with Main-Class", func() {
+		it.Before(func() {
+			Expect(os.MkdirAll(filepath.Join(path, "META-INF"), 0755)).To(Succeed())
+			Expect(ioutil.WriteFile(
+				filepath.Join(path, "META-INF", "MANIFEST.MF"),
+				[]byte("Main-Class: test-main-class"),
+				0644,
+			)).To(Succeed())
+		})
 
-		Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{
-			Pass: true,
-			Plans: []libcnb.BuildPlan{
-				{
-					Provides: []libcnb.BuildPlanProvide{
-						{Name: "jvm-application"},
-					},
-					Requires: []libcnb.BuildPlanRequire{
-						{Name: "jre", Metadata: map[string]interface{}{"launch": true}},
-						{Name: "jvm-application"},
+		it("requires and provides jvm-application-package", func() {
+			Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{
+				Pass: true,
+				Plans: []libcnb.BuildPlan{
+					{
+						Provides: []libcnb.BuildPlanProvide{
+							{Name: "jvm-application"},
+							{Name: "jvm-application-package"},
+						},
+						Requires: []libcnb.BuildPlanRequire{
+							{Name: "jre", Metadata: map[string]interface{}{"launch": true}},
+							{Name: "jvm-application-package"},
+							{Name: "jvm-application"},
+						},
 					},
 				},
-			},
-		}))
+			}))
+		})
 	})
 }


### PR DESCRIPTION
Previously we used the jvm-application build plan entry to represent two concepts

1. package containing application bytecode
1. process types and configuration that will launch JVM application in the final image

This PR uses a new entry called `jvm-application-package` to represent application bytecode. Creating this distinction makes the role a given buildpack plays clearer and solves a practical problem. Previously, when building from source code the `jvm-application` plan entry was being met by a build system buildpack (e.g. `paketo-buildpacks/maven`) and therefore not passed to buildpacks that contribute start commands (like `paketo-buildpacks/executable-jar`). Therefore, if a downstream buildpack wanted to add metadata to the `jvm-application` plan entry, intended to modify the behavior of a JVM application buildpack, that metadata would not be present if the image was built from source.

This depends on coordinated changes in the build system buildpacks:
* https://github.com/paketo-buildpacks/maven/pull/48
* https://github.com/paketo-buildpacks/gradle/pull/57
* https://github.com/paketo-buildpacks/leiningen/pull/43
* https://github.com/paketo-buildpacks/sbt/pull/54

Resulting improvements for native image builds from source:
 * don't set `CLASSPATH` in the launch environment when building a native image
 * don't contribute process types when building a native image
 * do set `CLASSPATH` in build environment
