### PR TITLE
Optionally request the same major version of JRE as specified in the MANIFEST.MF

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,15 @@ When `$BP_LIVE_RELOAD_ENABLE` is true:
 * Requests that `watchexec` be installed
 * Contributes `reload` process type
 
+When `$BP_JRE_VERSION_FROM_MANIFEST` is true:
+* If `<APPLICATION_ROOT>/META-INF/MANIFEST.MF` `Build-Jdk-Spec` exists
+  * Requests that a JRE of a specific major version should be installed.
+
 ## Configuration
-| Environment Variable      | Description                                       |
-| ------------------------- | ------------------------------------------------- |
-| `$BP_LIVE_RELOAD_ENABLED` | Enable live process reloading. Defaults to false. |
+| Environment Variable            | Description                                               |
+| --------------------------------| --------------------------------------------------------- |
+| `$BP_LIVE_RELOAD_ENABLED`       | Enable live process reloading. Defaults to false.         |
+| `$BP_JRE_VERSION_FROM_MANIFEST` | Request the same major version of JRE. Defaults to false. |
 
 ## License
 This buildpack is released under version 2.0 of the [Apache License][a].

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -42,6 +42,12 @@ description = "enable live process reload in the image"
 default     = "false"
 build       = true
 
+[[metadata.configurations]]
+name        = "BP_JRE_VERSION_FROM_MANIFEST"
+description = "require jre of the same major version as specified in the 'Build-Jdk-Spec' metadata field"
+default     = "false"
+build       = true
+
 [metadata]
 pre-package   = "scripts/build.sh"
 include-files = [


### PR DESCRIPTION
## Summary
<!-- A short explanation of the proposed change -->
Added `$BP_JRE_VERSION_FROM_MANIFEST` env variable, to enable JRE version extract from the MANIFEST.MF (`Build-Jdk-Spec` field)

## Use Cases
<!-- An explanation of the use cases your change enables -->
The version of the requested JRE should be picked up by the downstream buildpack (e.g. https://github.com/paketo-buildpacks/bellsoft-liberica/pull/191). By default, buildpack which provides the JVM, will contribute the default version (specified in the `buildpack.toml`).
For example, packaging a JAR file locally using the JVM `v17` and using `pack` to build an image, by default (without explicitly setting the `BP_JVM_VERSION`) will result in the JVM `v11` to be contributed.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
