### PR TITLE
Multijar support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,43 @@
 # `gcr.io/paketo-buildpacks/executable-jar`
+
 The Paketo Executable JAR Buildpack is a Cloud Native Buildpack that contributes a Process Type for executable JARs.
 
 ## Behavior
+
 This buildpack will participate if all the following conditions are met:
 
 * `<APPLICATION_ROOT>/META-INF/MANIFEST.MF` contains a `Main-Class` entry
+* `<APPLICATION_ROOT>/**/*.jar` exists and that JAR has a `/META-INF/MANIFEST.MF` file which contains a `Main-Class` entry
 
 When building a JVM application the buildpack will do the following:
+
 * Requests that a JRE be installed
-* Contributes `<APPLICATION_ROOT>` to build and runtime `$CLASSPATH`
-* If `<APPLICATION_ROOT>/META-INF/MANIFEST.MF` `Class-Path` exists
-  * Contributes entries to build and runtime `$CLASSPATH`
+* If `<APPLICATION_ROOT>` contains an exploded JAR:
+  * It contributes `<APPLICATION_ROOT>` to build and runtime `$CLASSPATH`
+  * If `<APPLICATION_ROOT>/META-INF/MANIFEST.MF` `Class-Path` exists
+    * Contributes entries to build and runtime `$CLASSPATH`
 * Contributes `executable-jar`, `task`, and `web` process types
 
 When participating in the build of a native image application the buildpack will:
-* Contributes `<APPLICATION_ROOT>` to build-time `$CLASSPATH`
-* If `<APPLICATION_ROOT>/META-INF/MANIFEST.MF` `Class-Path` exists
-  * Contributes entries to build-time `$CLASSPATH`
+
+* If `<APPLICATION_ROOT>` contains an exploded JAR:
+  * Contributes `<APPLICATION_ROOT>` to build-time `$CLASSPATH`
+  * If `<APPLICATION_ROOT>/META-INF/MANIFEST.MF` `Class-Path` exists
+    * Contributes entries to build-time `$CLASSPATH`
 
 When `$BP_LIVE_RELOAD_ENABLE` is true:
+
 * Requests that `watchexec` be installed
 * Contributes `reload` process type
 
 ## Configuration
+
 | Environment Variable      | Description                                       |
 | ------------------------- | ------------------------------------------------- |
 | `$BP_LIVE_RELOAD_ENABLED` | Enable live process reloading. Defaults to false. |
 
 ## License
+
 This buildpack is released under version 2.0 of the [Apache License][a].
 
 [a]: http://www.apache.org/licenses/LICENSE-2.0

--- a/executable/build.go
+++ b/executable/build.go
@@ -17,18 +17,13 @@
 package executable
 
 import (
-	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 
-	"github.com/magiconair/properties"
 	"github.com/paketo-buildpacks/libpak/effect"
 	"github.com/paketo-buildpacks/libpak/sbom"
 
 	"github.com/buildpacks/libcnb"
-	"github.com/paketo-buildpacks/libjvm"
 	"github.com/paketo-buildpacks/libpak"
 	"github.com/paketo-buildpacks/libpak/bard"
 )
@@ -41,73 +36,16 @@ type Build struct {
 func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 	result := libcnb.NewBuildResult()
 
-	// Check if there is a top-level META-INF/MANIFEST.MF
-	manifest := filepath.Join(context.Application.Path, "META-INF", "MANIFEST.MF")
-	manifestExists := true
-	if _, err := os.Stat(manifest); errors.Is(err, os.ErrNotExist) {
-		manifestExists = false
+	execJar, err := LoadExecutableJAR(context.Application.Path)
+	if err != nil {
+		return libcnb.BuildResult{}, fmt.Errorf("unable to load executable JAR\n%w", err)
 	}
 
-	mainJar := ""
-	m := properties.NewProperties()
-
-	if manifestExists {
-		var err error
-		m, err = libjvm.NewManifest(context.Application.Path)
-		if err != nil {
-			return libcnb.BuildResult{}, fmt.Errorf("unable to read manifest in %s\n%w", context.Application.Path, err)
+	if !execJar.Executable {
+		for _, entry := range context.Plan.Entries {
+			result.Unmet = append(result.Unmet, libcnb.UnmetPlanEntry{Name: entry.Name})
 		}
-	} else {
-		// walk through directories, find the JAR file with a Main-Class
-		err := filepath.Walk(context.Application.Path, func(path string, info os.FileInfo, err error) error {
-			if err != nil {
-				return err
-			}
-
-			// opt-out if we already found a JAR file
-			if mainJar != "" {
-				return nil
-			}
-
-			// make sure it is a file
-			if info.IsDir() {
-				return nil
-			}
-
-			// make sure it is a JAR file
-			if !strings.HasSuffix(path, ".jar") {
-				return nil
-			}
-
-			// get the MANIFEST of the JAR file
-			manifest, err := libjvm.NewManifestFromJAR(path)
-			if err != nil {
-				return err
-			}
-
-			// we take it if it has a Main-Class
-			if _, ok := manifest.Get("Main-Class"); ok {
-				mainJar = path
-			}
-
-			return nil
-		})
-
-		if err != nil {
-			return libcnb.BuildResult{}, err
-		}
-	}
-
-	mainClass := ""
-	if mainJar == "" {
-		var ok bool
-		mainClass, ok = m.Get("Main-Class")
-		if !ok {
-			for _, entry := range context.Plan.Entries {
-				result.Unmet = append(result.Unmet, libcnb.UnmetPlanEntry{Name: entry.Name})
-			}
-			return result, nil
-		}
+		return result, nil
 	}
 
 	b.Logger.Title(context.Buildpack)
@@ -130,15 +68,15 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 	}
 
 	if launch {
+		command := "java"
 		arguments := []string{}
 
-		if mainClass != "" {
-			arguments = append(arguments, mainClass)
+		if execJar.ExplodedJAR {
+			arguments = append(arguments, execJar.MainClass)
 		} else {
-			arguments = append(arguments, "-jar", mainJar)
+			arguments = append(arguments, "-jar", execJar.Path)
 		}
 
-		command := "java"
 		result.Processes = append(result.Processes,
 			libcnb.Process{
 				Type:      "executable-jar",
@@ -185,9 +123,9 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 		}
 	}
 
-	if mainJar == "" {
+	if execJar.ExplodedJAR {
 		cp := []string{context.Application.Path}
-		if s, ok := m.Get("Class-Path"); ok {
+		if s, ok := execJar.Properties.Get("Class-Path"); ok {
 			cp = append(cp, strings.Split(s, " ")...)
 		}
 

--- a/executable/build_test.go
+++ b/executable/build_test.go
@@ -17,8 +17,6 @@
 package executable_test
 
 import (
-	"archive/zip"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -290,24 +288,10 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		})
 	})
 
-	var createJARFile = func(fileName string, mainClass string) {
-		archive, err := os.Create(filepath.Join(ctx.Application.Path, fileName))
-		Expect(err).NotTo(HaveOccurred())
-		defer archive.Close()
-		zipWriter := zip.NewWriter(archive)
-
-		if mainClass != "" {
-			manifestWriter, err := zipWriter.Create("META-INF/MANIFEST.MF")
-			Expect(err).NotTo(HaveOccurred())
-			manifestWriter.Write([]byte(fmt.Sprintf("Main-Class: %s", mainClass)))
-		}
-		zipWriter.Close()
-	}
-
 	context("JAR files with a Main-Class", func() {
 		it.Before(func() {
-			createJARFile("a.jar", "test.Main")
-			createJARFile("b.jar", "")
+			Expect(CreateJAR(filepath.Join(ctx.Application.Path, "a.jar"), map[string]string{"Main-Class": "test.Main"})).To(Succeed())
+			Expect(CreateJAR(filepath.Join(ctx.Application.Path, "b.jar"), map[string]string{})).To(Succeed())
 		})
 
 		it("contributes Executable JAR with java -jar and without ClassPath layer", func() {
@@ -342,8 +326,8 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 	context("JAR files without a Main-Class", func() {
 		it.Before(func() {
-			createJARFile("a.jar", "")
-			createJARFile("b.jar", "")
+			Expect(CreateJAR(filepath.Join(ctx.Application.Path, "a.jar"), map[string]string{})).To(Succeed())
+			Expect(CreateJAR(filepath.Join(ctx.Application.Path, "b.jar"), map[string]string{})).To(Succeed())
 		})
 
 		it("return unmet jvm-application plan entry", func() {

--- a/executable/executable_jar.go
+++ b/executable/executable_jar.go
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2018-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package executable
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/magiconair/properties"
+	"github.com/paketo-buildpacks/libjvm"
+)
+
+type ExecutableJAR struct {
+	MainClass   string
+	Path        string
+	Properties  *properties.Properties
+	Executable  bool
+	ExplodedJAR bool
+}
+
+func LoadExecutableJAR(appPath string) (ExecutableJAR, error) {
+	_, err := os.Stat(filepath.Join(appPath, "META-INF", "MANIFEST.MF"))
+	if err != nil && !os.IsNotExist(err) {
+		return ExecutableJAR{}, fmt.Errorf("unable to read manifest.mf\n%w", err)
+	}
+
+	explodedJAR := !(err != nil && os.IsNotExist(err))
+	var props *properties.Properties
+	var jarPath = appPath
+
+	if explodedJAR {
+		props, err = libjvm.NewManifest(appPath)
+		if err != nil {
+			return ExecutableJAR{}, fmt.Errorf("unable to parse manifest\n%w", err)
+		}
+	} else {
+		jarPath, props, err = findExecutableJAR(appPath)
+		if err != nil {
+			return ExecutableJAR{}, fmt.Errorf("unable to parse manifest\n%w", err)
+		}
+	}
+
+	if mc, ok := props.Get("Main-Class"); ok {
+		return ExecutableJAR{
+			MainClass:   mc,
+			Properties:  props,
+			Path:        jarPath,
+			Executable:  ok,
+			ExplodedJAR: appPath == jarPath,
+		}, nil
+	}
+
+	return ExecutableJAR{}, nil
+}
+
+func findExecutableJAR(appPath string) (string, *properties.Properties, error) {
+	props := &properties.Properties{}
+	jarPath := ""
+	stopWalk := errors.New("stop walking")
+
+	err := filepath.Walk(appPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// make sure it is a file
+		if info.IsDir() {
+			return nil
+		}
+
+		// make sure it is a JAR file
+		if !strings.HasSuffix(path, ".jar") {
+			return nil
+		}
+
+		// get the MANIFEST of the JAR file
+		props, err = libjvm.NewManifestFromJAR(path)
+		if err != nil {
+			return fmt.Errorf("unable to load manifest\n%w", err)
+		}
+
+		// we take it if it has a Main-Class
+		if _, ok := props.Get("Main-Class"); ok {
+			jarPath = path
+			return stopWalk
+		}
+
+		return nil
+	})
+
+	if err != nil && !errors.Is(err, stopWalk) {
+		return "", nil, err
+	}
+
+	return jarPath, props, nil
+}

--- a/executable/executable_jar_test.go
+++ b/executable/executable_jar_test.go
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2018-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package executable_test
+
+import (
+	"archive/zip"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/paketo-buildpacks/executable-jar/v6/executable"
+	"github.com/sclevine/spec"
+)
+
+func testManifest(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect  = NewWithT(t).Expect
+		appPath string
+	)
+
+	it.Before(func() {
+		var err error
+
+		appPath, err = ioutil.TempDir("", "manifest")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	it.After(func() {
+		Expect(os.RemoveAll(appPath)).To(Succeed())
+	})
+
+	context("exploded JAR", func() {
+		it("fail if not executable", func() {
+			Expect(os.MkdirAll(filepath.Join(appPath, "META-INF"), 0755)).To(Succeed())
+			Expect(ioutil.WriteFile(
+				filepath.Join(appPath, "META-INF", "MANIFEST.MF"),
+				[]byte(`foo: bar`),
+				0644,
+			)).To(Succeed())
+
+			ej, err := executable.LoadExecutableJAR(appPath)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ej.Executable).To(BeFalse())
+			Expect(ej.ExplodedJAR).To(BeFalse())
+			Expect(ej.MainClass).To(BeEmpty())
+		})
+
+		it("fail if file not found", func() {
+			ej, err := executable.LoadExecutableJAR(appPath)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ej.Executable).To(BeFalse())
+			Expect(ej.ExplodedJAR).To(BeFalse())
+			Expect(ej.MainClass).To(BeEmpty())
+		})
+
+		it("loads executable JAR properties", func() {
+			Expect(os.MkdirAll(filepath.Join(appPath, "META-INF"), 0755)).To(Succeed())
+			Expect(ioutil.WriteFile(
+				filepath.Join(appPath, "META-INF", "MANIFEST.MF"),
+				[]byte(`Main-Class: Foo`),
+				0644,
+			)).To(Succeed())
+
+			ej, err := executable.LoadExecutableJAR(appPath)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ej.MainClass).To(Equal("Foo"))
+			Expect(ej.Path).To(Equal(appPath))
+			Expect(ej.ExplodedJAR).To(BeTrue())
+			Expect(ej.Executable).To(BeTrue())
+			Expect(ej.Properties.Map()).To(HaveKeyWithValue("Main-Class", "Foo"))
+		})
+	})
+
+	context("executable JAR", func() {
+		it("fails if it can't find an executable JAR", func() {
+			Expect(CreateJAR(filepath.Join(appPath, "test-1.jar"), map[string]string{"foo": "bar"})).To(Succeed())
+
+			ej, err := executable.LoadExecutableJAR(appPath)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ej.Executable).To(BeFalse())
+			Expect(ej.ExplodedJAR).To(BeFalse())
+			Expect(ej.MainClass).To(BeEmpty())
+		})
+
+		it("loads props from an executable JAR", func() {
+			Expect(CreateJAR(filepath.Join(appPath, "test-1.jar"), map[string]string{"Main-Class": "Foo"})).To(Succeed())
+
+			ej, err := executable.LoadExecutableJAR(appPath)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ej.MainClass).To(Equal("Foo"))
+			Expect(ej.Path).To(Equal(filepath.Join(appPath, "test-1.jar")))
+			Expect(ej.ExplodedJAR).To(BeFalse())
+			Expect(ej.Executable).To(BeTrue())
+			Expect(ej.Properties.Map()).To(HaveKeyWithValue("Main-Class", "Foo"))
+		})
+
+		it("loads props from first executable JAR found", func() {
+			Expect(CreateJAR(filepath.Join(appPath, "test-1.jar"), map[string]string{"Main-Class": "Foo1"})).To(Succeed())
+			Expect(CreateJAR(filepath.Join(appPath, "test-2.jar"), map[string]string{"Main-Class": "Foo2"})).To(Succeed())
+
+			ej, err := executable.LoadExecutableJAR(appPath)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ej.MainClass).To(Equal("Foo1"))
+			Expect(ej.Path).To(Equal(filepath.Join(appPath, "test-1.jar")))
+			Expect(ej.ExplodedJAR).To(BeFalse())
+			Expect(ej.Executable).To(BeTrue())
+			Expect(ej.Properties.Map()).To(HaveKeyWithValue("Main-Class", "Foo1"))
+		})
+
+		it("skips non-executable JARs", func() {
+			Expect(CreateJAR(filepath.Join(appPath, "test-1.jar"), map[string]string{"foo": "bar"})).To(Succeed())
+			Expect(CreateJAR(filepath.Join(appPath, "test-2.jar"), map[string]string{"Main-Class": "Foo2"})).To(Succeed())
+
+			ej, err := executable.LoadExecutableJAR(appPath)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ej.MainClass).To(Equal("Foo2"))
+			Expect(ej.Path).To(Equal(filepath.Join(appPath, "test-2.jar")))
+			Expect(ej.ExplodedJAR).To(BeFalse())
+			Expect(ej.Executable).To(BeTrue())
+			Expect(ej.Properties.Map()).To(HaveKeyWithValue("Main-Class", "Foo2"))
+		})
+	})
+}
+
+func CreateJAR(fileName string, props map[string]string) error {
+	archive, err := os.Create(fileName)
+	if err != nil {
+		return fmt.Errorf("unable to create zip\n%w", err)
+	}
+	defer archive.Close()
+
+	zipWriter := zip.NewWriter(archive)
+
+	if props != nil {
+		manifestWriter, err := zipWriter.Create("META-INF/MANIFEST.MF")
+		if err != nil {
+			return fmt.Errorf("unable to create file in zip\n%w", err)
+		}
+
+		for k, v := range props {
+			_, err = manifestWriter.Write([]byte(fmt.Sprintf("%s: %s", k, v)))
+			if err != nil {
+				return fmt.Errorf("unable to write file in zip\n%w", err)
+			}
+		}
+	}
+
+	return zipWriter.Close()
+}

--- a/executable/init_test.go
+++ b/executable/init_test.go
@@ -28,5 +28,6 @@ func TestUnit(t *testing.T) {
 	suite("Build", testBuild)
 	suite("ClassPath", testClassPath)
 	suite("Detect", testDetect)
+	suite("Manifest", testManifest)
 	suite.Run(t)
 }


### PR DESCRIPTION
Superceeds #118 and Fixes #112

## Summary

This is based on the [discussion in slack](https://paketobuildpacks.slack.com/archives/C0124SD3GTG/p1647007132121259).

When there are multiple JAR files, then all of them are added to the class path. The current implementation takes the first found Main-Class from a MANIFEST.MF, but that might need additional flexibility, see question 1 below.

Making this a draft until the new [NewJarManifest function in libjvm is available](https://github.com/paketo-buildpacks/libjvm/pull/153)

Open question:

1. In case of multiple JAR files with a main class, the first one would be picked. We might want to allow an override. We could introduce an environment variable to pick the JAR file which then must contain a Main-Class, or introduce an environment variable to allow the user to specify the Main class name. I prefer the latter as it is more flexible (supports the scenario where the Main class is not defined in the JAR file), and because JAR file names can contain versions so that one would maybe need to support patterns, which could potentially not lead to a single JAR file again.

## Use Cases

As user using a Maven or Gradle build that produces multiple JAR files, I want the Paketo Buildpacks to automatically determine the first available Main-Class from those JAR files and define them as image entrypoint.

## Checklist
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
