### PR TITLE
Set no shell and include `--` to protect command argments

### DIFF
--- a/executable/build.go
+++ b/executable/build.go
@@ -100,6 +100,10 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 		)
 
 		if cr.ResolveBool("BP_LIVE_RELOAD_ENABLED") {
+			if !execJar.ExplodedJAR {
+				b.Logger.Body("WARNING: Live Reload has been enabled, however, your command is set to run from a JAR file. This may fail or be a worse experience as the entire JAR file must change to trigger a reload.")
+			}
+
 			for i := 0; i < len(result.Processes); i++ {
 				result.Processes[i].Default = false
 			}
@@ -108,7 +112,7 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 				libcnb.Process{
 					Type:      "reload",
 					Command:   "watchexec",
-					Arguments: append([]string{"-r", command}, arguments...),
+					Arguments: append([]string{"-r", "--shell=none", "--", command}, arguments...),
 					Direct:    true,
 					Default:   true,
 				},

--- a/executable/build_test.go
+++ b/executable/build_test.go
@@ -230,7 +230,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 					libcnb.Process{
 						Type:      "reload",
 						Command:   "watchexec",
-						Arguments: []string{"-r", "java", "test-main-class"},
+						Arguments: []string{"-r", "--shell=none", "--", "java", "test-main-class"},
 						Direct:    true,
 						Default:   true,
 					},


### PR DESCRIPTION
## Summary

1. Force `watchexec` to use no shell. This enables reloading to work when using the tiny stack. It also removes an extra process in the container.
2. Add the double-dash. The `--` tells `watchexec` to not try parsing arguments after the `--`. This could be a problem if the start command that `watchexec` is running has its own arguments to parse.
3. Adds a WARNING message if the build-from-source results in multiple-artifacts, which in turn results in executable-jar setting the process type to run with `java -jar`. This is a problem because then you would need to rebuild your JAR on every local change and have Tilt send over the entire JAR file to trigger a reload and see your change. It's much easier if the build produces a single artifact, then we can run from an exploded JAR and tilt only needs to send over the class files that have changed.

This resolves #117 and resolves #130

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
