### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `gcr.io/paketo-buildpacks/executable-jar`
 
-The Paketo Executable JAR Buildpack is a Cloud Native Buildpack that contributes a Process Type for executable JARs.
+The Paketo Buildpack for Executable JAR is a Cloud Native Buildpack that contributes a Process Type for executable JARs.
 
 ## Behavior
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -16,7 +16,7 @@ api = "0.7"
 
 [buildpack]
   id       = "paketo-buildpacks/executable-jar"
-  name     = "Paketo Executable JAR Buildpack"
+  name     = "Paketo Buildpack for Executable JAR"
   version  = "{{.version}}"
   homepage = "https://github.com/paketo-buildpacks/executable-jar"
   description = "A Cloud Native Buildpack that contributes a Process Type for executable JARs"


### PR DESCRIPTION
Renames 'Paketo Executable JAR Buildpack' to 'Paketo Buildpack for Executable JAR'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
