### PR TITLE
Marks all workspace files as group read-write on live reload enabled

### DIFF
--- a/executable/build.go
+++ b/executable/build.go
@@ -18,6 +18,9 @@ package executable
 
 import (
 	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/paketo-buildpacks/libpak/effect"
@@ -117,6 +120,20 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 					Default:   true,
 				},
 			)
+
+			err = filepath.Walk(context.Application.Path, func(path string, info fs.FileInfo, err error) error {
+				if err != nil {
+					return err
+				}
+				if path == context.Application.Path {
+					return nil
+				}
+
+				return os.Chmod(path, info.Mode()|0060)
+			})
+			if err != nil {
+				return libcnb.BuildResult{}, fmt.Errorf("unable to mark files as group read-write for live reload\n%w", err)
+			}
 		}
 
 		if b.SBOMScanner == nil {


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
The "live reload" functionality of this buildpack is broken on Jammy stacks. Specifically, the run user cannot update files because the group write permissions are not set on all files in `/workspace`. This PR includes code that walks the directory and marks all files in `/workspace` with group read-write permissions so that this feature can be enabled.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
