### PR TITLE
feat: use BFS to find executable jar

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ When `$BP_LIVE_RELOAD_ENABLE` is true:
 
 ## Configuration
 
-| Environment Variable      | Description                                       |
-| ------------------------- | ------------------------------------------------- |
-| `$BP_LIVE_RELOAD_ENABLED` | Enable live process reloading. Defaults to false. |
-
+| Environment Variable          | Description                                                                                                                                                               |
+|-------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `$BP_LIVE_RELOAD_ENABLED`     | Enable live process reloading. Defaults to false.                                                                                                                         |
+| `$BP_EXECUTABLE_JAR_LOCATION` | An optional glob to specify the JAR used as an entrypoint. Defaults to "", which causes the buildpack to do a breadth-first search for the first executable JAR it finds. |
 ## License
 
 This buildpack is released under version 2.0 of the [Apache License][a].

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -42,6 +42,12 @@ description = "enable live process reload in the image"
 default     = "false"
 build       = true
 
+[[metadata.configurations]]
+name        = "BP_EXECUTABLE_JAR_LOCATION"
+description = "a glob specifying which jar files should be used"
+default     = ""
+build       = true
+
 [metadata]
 pre-package   = "scripts/build.sh"
 include-files = [

--- a/executable/build.go
+++ b/executable/build.go
@@ -39,7 +39,13 @@ type Build struct {
 func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 	result := libcnb.NewBuildResult()
 
-	execJar, err := LoadExecutableJAR(context.Application.Path)
+	cr, err := libpak.NewConfigurationResolver(context.Buildpack, nil)
+	if err != nil {
+		return libcnb.BuildResult{}, fmt.Errorf("unable to create configuration resolver\n%w", err)
+	}
+
+	jarGlob, _ := cr.Resolve("BP_EXECUTABLE_JAR_LOCATION")
+	execJar, err := LoadExecutableJAR(context.Application.Path, jarGlob)
 	if err != nil {
 		return libcnb.BuildResult{}, fmt.Errorf("unable to load executable JAR\n%w", err)
 	}
@@ -53,7 +59,7 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 
 	b.Logger.Title(context.Buildpack)
 
-	cr, err := libpak.NewConfigurationResolver(context.Buildpack, nil)
+	cr, err = libpak.NewConfigurationResolver(context.Buildpack, nil)
 	if err != nil {
 		return libcnb.BuildResult{}, fmt.Errorf("unable to create configuration resolver\n%w", err)
 	}

--- a/executable/executable_jar.go
+++ b/executable/executable_jar.go
@@ -37,7 +37,7 @@ type ExecutableJAR struct {
 	ExplodedJAR bool
 }
 
-func LoadExecutableJAR(appPath string) (ExecutableJAR, error) {
+func LoadExecutableJAR(appPath string, executableJarGlob string) (ExecutableJAR, error) {
 	_, err := os.Stat(filepath.Join(appPath, "META-INF", "MANIFEST.MF"))
 	if err != nil && !os.IsNotExist(err) {
 		return ExecutableJAR{}, fmt.Errorf("unable to read manifest.mf\n%w", err)
@@ -53,7 +53,7 @@ func LoadExecutableJAR(appPath string) (ExecutableJAR, error) {
 			return ExecutableJAR{}, fmt.Errorf("unable to parse manifest\n%w", err)
 		}
 	} else {
-		jarPath, props, err = findExecutableJAR(appPath)
+		jarPath, props, err = findExecutableJAR(appPath, executableJarGlob)
 		if err != nil {
 			return ExecutableJAR{}, fmt.Errorf("unable to parse manifest\n%w", err)
 		}
@@ -72,12 +72,26 @@ func LoadExecutableJAR(appPath string) (ExecutableJAR, error) {
 	return ExecutableJAR{}, nil
 }
 
-func findExecutableJAR(appPath string) (string, *properties.Properties, error) {
+func findExecutableJAR(appPath, executableJarGlob string) (string, *properties.Properties, error) {
 	props := &properties.Properties{}
 	jarPath := ""
 	stopWalk := errors.New("stop walking")
 
-	err := fsutil.Walk(appPath, func(path string, info os.FileInfo, err error) error {
+	w := func(root string, fn filepath.WalkFunc) error {
+		if executableJarGlob != "" {
+			files, _ := filepath.Glob(filepath.Join(appPath, executableJarGlob))
+			for _, f := range files {
+				fi, err := os.Lstat(f)
+				err = fn(f, fi, err)
+				if err != nil {
+					return err
+				}
+			}
+		}
+		return fsutil.Walk(root, fn)
+	}
+
+	err := w(appPath, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}

--- a/executable/executable_jar.go
+++ b/executable/executable_jar.go
@@ -25,6 +25,8 @@ import (
 
 	"github.com/magiconair/properties"
 	"github.com/paketo-buildpacks/libjvm"
+
+	"github.com/paketo-buildpacks/executable-jar/v6/internal/fsutil"
 )
 
 type ExecutableJAR struct {
@@ -75,7 +77,7 @@ func findExecutableJAR(appPath string) (string, *properties.Properties, error) {
 	jarPath := ""
 	stopWalk := errors.New("stop walking")
 
-	err := filepath.Walk(appPath, func(path string, info os.FileInfo, err error) error {
+	err := fsutil.Walk(appPath, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}

--- a/executable/executable_jar_test.go
+++ b/executable/executable_jar_test.go
@@ -117,6 +117,8 @@ func testManifest(t *testing.T, context spec.G, it spec.S) {
 		})
 
 		it("loads props from first executable JAR found", func() {
+			Expect(os.MkdirAll(filepath.Join(appPath, "lib"), 0755))
+			Expect(CreateJAR(filepath.Join(appPath, "lib", "a.jar"), map[string]string{"Main-Class": "Lib1"})).To(Succeed())
 			Expect(CreateJAR(filepath.Join(appPath, "test-1.jar"), map[string]string{"Main-Class": "Foo1"})).To(Succeed())
 			Expect(CreateJAR(filepath.Join(appPath, "test-2.jar"), map[string]string{"Main-Class": "Foo2"})).To(Succeed())
 

--- a/executable/executable_jar_test.go
+++ b/executable/executable_jar_test.go
@@ -55,7 +55,7 @@ func testManifest(t *testing.T, context spec.G, it spec.S) {
 				0644,
 			)).To(Succeed())
 
-			ej, err := executable.LoadExecutableJAR(appPath)
+			ej, err := executable.LoadExecutableJAR(appPath, "")
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(ej.Executable).To(BeFalse())
@@ -64,7 +64,7 @@ func testManifest(t *testing.T, context spec.G, it spec.S) {
 		})
 
 		it("fail if file not found", func() {
-			ej, err := executable.LoadExecutableJAR(appPath)
+			ej, err := executable.LoadExecutableJAR(appPath, "")
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(ej.Executable).To(BeFalse())
@@ -80,7 +80,7 @@ func testManifest(t *testing.T, context spec.G, it spec.S) {
 				0644,
 			)).To(Succeed())
 
-			ej, err := executable.LoadExecutableJAR(appPath)
+			ej, err := executable.LoadExecutableJAR(appPath, "")
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(ej.MainClass).To(Equal("Foo"))
@@ -95,7 +95,7 @@ func testManifest(t *testing.T, context spec.G, it spec.S) {
 		it("fails if it can't find an executable JAR", func() {
 			Expect(CreateJAR(filepath.Join(appPath, "test-1.jar"), map[string]string{"foo": "bar"})).To(Succeed())
 
-			ej, err := executable.LoadExecutableJAR(appPath)
+			ej, err := executable.LoadExecutableJAR(appPath, "")
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(ej.Executable).To(BeFalse())
@@ -106,7 +106,7 @@ func testManifest(t *testing.T, context spec.G, it spec.S) {
 		it("loads props from an executable JAR", func() {
 			Expect(CreateJAR(filepath.Join(appPath, "test-1.jar"), map[string]string{"Main-Class": "Foo"})).To(Succeed())
 
-			ej, err := executable.LoadExecutableJAR(appPath)
+			ej, err := executable.LoadExecutableJAR(appPath, "")
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(ej.MainClass).To(Equal("Foo"))
@@ -122,7 +122,7 @@ func testManifest(t *testing.T, context spec.G, it spec.S) {
 			Expect(CreateJAR(filepath.Join(appPath, "test-1.jar"), map[string]string{"Main-Class": "Foo1"})).To(Succeed())
 			Expect(CreateJAR(filepath.Join(appPath, "test-2.jar"), map[string]string{"Main-Class": "Foo2"})).To(Succeed())
 
-			ej, err := executable.LoadExecutableJAR(appPath)
+			ej, err := executable.LoadExecutableJAR(appPath, "")
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(ej.MainClass).To(Equal("Foo1"))
@@ -132,11 +132,27 @@ func testManifest(t *testing.T, context spec.G, it spec.S) {
 			Expect(ej.Properties.Map()).To(HaveKeyWithValue("Main-Class", "Foo1"))
 		})
 
+		it("loads props from executable JAR specified by glob", func() {
+			Expect(os.MkdirAll(filepath.Join(appPath, "lib"), 0755))
+			Expect(CreateJAR(filepath.Join(appPath, "lib", "a.jar"), map[string]string{"Main-Class": "Lib1"})).To(Succeed())
+			Expect(CreateJAR(filepath.Join(appPath, "test-1.jar"), map[string]string{"Main-Class": "Foo1"})).To(Succeed())
+			Expect(CreateJAR(filepath.Join(appPath, "test-2.jar"), map[string]string{"Main-Class": "Foo2"})).To(Succeed())
+
+			ej, err := executable.LoadExecutableJAR(appPath, "*-2.jar")
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ej.MainClass).To(Equal("Foo2"))
+			Expect(ej.Path).To(Equal(filepath.Join(appPath, "test-2.jar")))
+			Expect(ej.ExplodedJAR).To(BeFalse())
+			Expect(ej.Executable).To(BeTrue())
+			Expect(ej.Properties.Map()).To(HaveKeyWithValue("Main-Class", "Foo2"))
+		})
+
 		it("skips non-executable JARs", func() {
 			Expect(CreateJAR(filepath.Join(appPath, "test-1.jar"), map[string]string{"foo": "bar"})).To(Succeed())
 			Expect(CreateJAR(filepath.Join(appPath, "test-2.jar"), map[string]string{"Main-Class": "Foo2"})).To(Succeed())
 
-			ej, err := executable.LoadExecutableJAR(appPath)
+			ej, err := executable.LoadExecutableJAR(appPath, "")
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(ej.MainClass).To(Equal("Foo2"))

--- a/internal/fsutil/walk.go
+++ b/internal/fsutil/walk.go
@@ -1,0 +1,64 @@
+package fsutil
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+func Walk(root string, walkFn filepath.WalkFunc) error {
+	type node struct {
+		next  *node
+		value string
+	}
+	var (
+		head = &node{value: root}
+		tail = head
+	)
+	var err error
+	for ; head != nil; head = head.next {
+		p := head.value
+		var fi fs.FileInfo
+		fi, err = os.Lstat(p)
+		if err != nil || !fi.IsDir() {
+			err = walkFn(p, fi, err)
+			if err != nil {
+				break
+			}
+			continue
+		}
+		var names []string
+		names, err = readDirNames(p)
+		err = walkFn(p, fi, err)
+		if err != nil {
+			if errors.Is(err, filepath.SkipDir) {
+				continue
+			}
+			break
+		}
+		for _, name := range names {
+			tail.next = &node{value: filepath.Join(p, name)}
+			tail = tail.next
+		}
+	}
+	if errors.Is(err, filepath.SkipAll) {
+		return nil
+	}
+	return err
+}
+
+func readDirNames(dirname string) ([]string, error) {
+	f, err := os.Open(dirname)
+	if err != nil {
+		return nil, err
+	}
+	names, err := f.Readdirnames(-1)
+	f.Close()
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(names)
+	return names, nil
+}

--- a/internal/fsutil/walk_test.go
+++ b/internal/fsutil/walk_test.go
@@ -1,0 +1,194 @@
+package fsutil_test
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/paketo-buildpacks/executable-jar/v6/internal/fsutil"
+)
+
+func TestWalkAgainstStdlibWalk(t *testing.T) {
+	type fileInfo struct {
+		Path string
+		Type fs.FileMode
+	}
+	createWalkFn := func(out *[]fileInfo) filepath.WalkFunc {
+		return func(path string, fi fs.FileInfo, err error) error {
+			if err != nil {
+				return nil
+			}
+			var typ fs.FileMode
+			if fi != nil {
+				typ = fi.Mode().Type()
+			}
+			*out = append(*out, fileInfo{
+				Path: path,
+				Type: typ,
+			})
+			return nil
+		}
+	}
+
+	type args struct {
+		root string
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "basic",
+			args: args{
+				root: createTestDir(t),
+			},
+		},
+		{
+			name: "non-existent root",
+			args: args{
+				root: filepath.Join(t.TempDir(), "nonexistent"),
+			},
+		},
+	}
+	for _, tt := range tests {
+
+		t.Run(tt.name, func(t *testing.T) {
+			var ourFiles, theirsFiles []fileInfo
+			errOurs := fsutil.Walk(tt.args.root, createWalkFn(&ourFiles))
+			errTheirs := filepath.Walk(tt.args.root, createWalkFn(&theirsFiles))
+
+			if (ourFiles == nil) != (theirsFiles == nil) {
+				t.Errorf("errors does not match, actual error: %#v, expected error: %#v", errOurs, errTheirs)
+			}
+
+			// sort output of filepath.Walk in BFS order
+			sort.SliceStable(theirsFiles, func(i, j int) bool {
+				iLen := len(strings.Split(theirsFiles[i].Path, string(filepath.Separator)))
+				jLen := len(strings.Split(theirsFiles[j].Path, string(filepath.Separator)))
+				return iLen < jLen
+			})
+
+			if d := cmp.Diff(theirsFiles, ourFiles); d != "" {
+				t.Error("output missmatch (-want, +got):", d)
+			}
+		})
+
+	}
+}
+
+func TestWalkSearch(t *testing.T) {
+	root := createTestDir(t)
+	sentinelErr := errors.New("sentinel")
+	var content string
+	err := fsutil.Walk(root, func(path string, fi fs.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if fi.Mode().Type() == 0 {
+			_, name := filepath.Split(path)
+			if name == "a.txt" {
+				bs, e := os.ReadFile(path)
+				if e != nil {
+					return e
+				}
+				content = string(bs)
+				return sentinelErr
+			}
+		}
+		return nil
+	})
+	if !errors.Is(err, sentinelErr) {
+		t.Errorf("incorrect return value, expected sentinel error but got: %v", err)
+	}
+	if content != "a1/a2/a.txt" {
+		t.Errorf("unexpected content: %q", content)
+	}
+}
+
+func TestWalkSearchWithSkipDir(t *testing.T) {
+	root := createTestDir(t)
+	sentinelErr := errors.New("sentinel")
+	var content string
+	err := fsutil.Walk(root, func(path string, fi fs.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		rp, err := filepath.Rel(root, path)
+		if rp == "a1" { // skip the first dir containing a.txt
+			return filepath.SkipDir
+		}
+		if fi.Mode().Type() == 0 {
+			_, name := filepath.Split(path)
+			if name == "a.txt" {
+				bs, e := os.ReadFile(path)
+				if e != nil {
+					return e
+				}
+				content = string(bs)
+				return sentinelErr
+			}
+		}
+		return nil
+	})
+	if !errors.Is(err, sentinelErr) {
+		t.Errorf("incorrect return value, expected sentinel error but got: %v", err)
+	}
+	if content != "c1/a2/a3/a.txt" {
+		t.Errorf("unexpected content: %q", content)
+	}
+}
+
+func createTestDir(t *testing.T) string {
+	root := t.TempDir()
+	var err error
+
+	var createChildrenDirs func(dir string, lvl int)
+	createChildrenDirs = func(dir string, lvl int) {
+		if lvl >= 4 {
+			return
+		}
+		for _, n := range []string{"a", "b", "c"} {
+			d := filepath.Join(dir, fmt.Sprintf("%s%d", n, lvl))
+			err := os.Mkdir(d, 0755)
+			if err != nil {
+				t.Fatal(err)
+			}
+			createChildrenDirs(d, lvl+1)
+		}
+	}
+	createChildrenDirs(root, 1)
+
+	err = os.Chmod(filepath.Join(root, "b1", "a2"), 0000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		err = os.Chmod(filepath.Join(root, "b1", "a2"), 0755)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	err = os.Symlink("a1", filepath.Join(root, "a.lnk"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = os.WriteFile(filepath.Join(root, "a1", "a2", "a.txt"), []byte(`a1/a2/a.txt`), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = os.WriteFile(filepath.Join(root, "c1", "a2", "a3", "a.txt"), []byte(`c1/a2/a3/a.txt`), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return root
+}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
* Search executable `*.jar` files using BFS over filesystem. This ensures that jar closest to project root is used.
* Added `BP_EXECUTABLE_JAR_LOCATION` envvar as an escape hatch in case BFS in not working well with some project.
### Rationale
Consider following artefacts structure:
```
workspace
├── lib
│   └── some-lib-that-is-also-executable.jar
└── quarkus-app.jar
```
In most cases user wants to use top level jar not some library jar that is coincidentally executable.
Older approach using `filepath.Walk()`, which uses  lexical order, would used `some-lib-that-is-also-executable.jar` which we do not want to.

## Use Cases
<!-- An explanation of the use cases your change enables -->
This is useful when project has a dependency which jar is executable.
For instance NLP library `edu.stanford.nlp:stanford-corenlp` depends on `xalan:serializer` which is executable. Developer using `edu.stanford.nlp:stanford-corenlp probably` most likely doesn't want `xalan:serializer`  as an entrypoint of the image.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
