### PR TITLE
Allow making an executable-jar image by only providing an executable JAR

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Paketo Buildpack for Executable JAR is a Cloud Native Buildpack that contrib
 
 ## Behavior
 
-This buildpack will participate if all the following conditions are met:
+This buildpack will participate if any the following conditions are met:
 
 * `<APPLICATION_ROOT>/META-INF/MANIFEST.MF` contains a `Main-Class` entry
 * `<APPLICATION_ROOT>/**/*.jar` exists and that JAR has a `/META-INF/MANIFEST.MF` file which contains a `Main-Class` entry

--- a/executable/detect.go
+++ b/executable/detect.go
@@ -33,7 +33,7 @@ const (
 	PlanEntrySyft                  = "syft"
 )
 
-type Detect struct{
+type Detect struct {
 	Logger bard.Logger
 }
 
@@ -65,8 +65,14 @@ func (d Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error
 		return libcnb.DetectResult{}, fmt.Errorf("unable to read manifest in %s\n%w", context.Application.Path, err)
 	}
 
+	jarGlob, _ := cr.Resolve("BP_EXECUTABLE_JAR_LOCATION")
+	_, props, _ := findExecutableJAR(context.Application.Path, jarGlob)
+
 	if _, ok := m.Get("Main-Class"); ok {
 		d.Logger.Info("PASSED: 'Main-Class' manifest attribute found")
+		result.Plans[0].Provides = append(result.Plans[0].Provides, libcnb.BuildPlanProvide{Name: PlanEntryJVMApplicationPackage})
+	} else if _, ok := props.Get("Main-Class"); ok {
+		d.Logger.Info("PASSED: Jar file with 'Main-Class' manifest attribute found")
 		result.Plans[0].Provides = append(result.Plans[0].Provides, libcnb.BuildPlanProvide{Name: PlanEntryJVMApplicationPackage})
 	}
 

--- a/executable/detect_test.go
+++ b/executable/detect_test.go
@@ -132,6 +132,32 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 		})
 	})
 
+	context("META-INF/MANIFEST.MF not found but there is JAR with Main-Class", func() {
+		it.Before(func() {
+			Expect(CreateJAR(filepath.Join(ctx.Application.Path, "a.jar"), map[string]string{"Main-Class": "test.Main"})).To(Succeed())
+		})
+
+		it("requires and provides jvm-application-package", func() {
+			Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{
+				Pass: true,
+				Plans: []libcnb.BuildPlan{
+					{
+						Provides: []libcnb.BuildPlanProvide{
+							{Name: "jvm-application"},
+							{Name: "jvm-application-package"},
+						},
+						Requires: []libcnb.BuildPlanRequire{
+							{Name: "syft"},
+							{Name: "jre", Metadata: map[string]interface{}{"launch": true}},
+							{Name: "jvm-application-package"},
+							{Name: "jvm-application"},
+						},
+					},
+				},
+			}))
+		})
+	})
+
 	context("$BP_LIVE_RELOAD_ENABLED is set", func() {
 		it.Before(func() {
 			Expect(os.Setenv("BP_LIVE_RELOAD_ENABLED", "true")).To(Succeed())


### PR DESCRIPTION
In this PR, I'm enabling the capability to only provide a standalone executable JAR without the need to have a file in META-INF/MANIFEST.MF

[Fixes #264]