### PR TITLE
Do not use effect.NewExecutor use CommandExecutor instead

### DIFF
--- a/executable/build.go
+++ b/executable/build.go
@@ -143,7 +143,7 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 		}
 
 		if b.SBOMScanner == nil {
-			b.SBOMScanner = sbom.NewSyftCLISBOMScanner(context.Layers, effect.NewExecutor(), b.Logger)
+			b.SBOMScanner = sbom.NewSyftCLISBOMScanner(context.Layers, effect.CommandExecutor{}, b.Logger)
 		}
 		if err := b.SBOMScanner.ScanLaunch(context.Application.Path, libcnb.SyftJSON, libcnb.CycloneDXJSON); err != nil {
 			return libcnb.BuildResult{}, fmt.Errorf("unable to create Build SBoM \n%w", err)

--- a/executable/build_test.go
+++ b/executable/build_test.go
@@ -19,7 +19,6 @@ package executable_test
 import (
 	"fmt"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -41,13 +40,8 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 	)
 
 	it.Before(func() {
-		var err error
-
-		ctx.Application.Path, err = ioutil.TempDir("", "build-application")
-		Expect(err).NotTo(HaveOccurred())
-
-		ctx.Layers.Path, err = ioutil.TempDir("", "build-layers")
-		Expect(err).NotTo(HaveOccurred())
+		ctx.Application.Path = t.TempDir()
+		ctx.Layers.Path = t.TempDir()
 
 		Expect(os.MkdirAll(filepath.Join(ctx.Application.Path, "META-INF"), 0755)).To(Succeed())
 		sbomScanner = mocks.SBOMScanner{}
@@ -62,7 +56,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 	context("manifest with Main-Class and Class-Path", func() {
 		it.Before(func() {
-			Expect(ioutil.WriteFile(
+			Expect(os.WriteFile(
 				filepath.Join(ctx.Application.Path, "META-INF", "MANIFEST.MF"),
 				[]byte("Main-Class: test-main-class"),
 				0644,
@@ -71,7 +65,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 		it("contributes process types and classpath", func() {
 			Expect(os.MkdirAll(filepath.Join(ctx.Application.Path, "META-INF"), 0755)).To(Succeed())
-			Expect(ioutil.WriteFile(
+			Expect(os.WriteFile(
 				filepath.Join(ctx.Application.Path, "META-INF", "MANIFEST.MF"),
 				[]byte("Main-Class: test-main-class\nClass-Path: test-class-path"),
 				0644,
@@ -108,7 +102,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 		context("manifest with Main-Class and without Class-Path", func() {
 			it.Before(func() {
-				Expect(ioutil.WriteFile(
+				Expect(os.WriteFile(
 					filepath.Join(ctx.Application.Path, "META-INF", "MANIFEST.MF"),
 					[]byte("Main-Class: test-main-class"),
 					0644,
@@ -117,7 +111,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 			it("contributes process types and classpath", func() {
 				Expect(os.MkdirAll(filepath.Join(ctx.Application.Path, "META-INF"), 0755)).To(Succeed())
-				Expect(ioutil.WriteFile(
+				Expect(os.WriteFile(
 					filepath.Join(ctx.Application.Path, "META-INF", "MANIFEST.MF"),
 					[]byte("Main-Class: test-main-class"),
 					0644,
@@ -155,7 +149,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 		it("contributes Executable JAR without Class-Path", func() {
 			Expect(os.MkdirAll(filepath.Join(ctx.Application.Path, "META-INF"), 0755)).To(Succeed())
-			Expect(ioutil.WriteFile(
+			Expect(os.WriteFile(
 				filepath.Join(ctx.Application.Path, "META-INF", "MANIFEST.MF"),
 				[]byte(`Main-Class: test-main-class`),
 				0644,
@@ -200,7 +194,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 			it("contributes reloadable process type", func() {
 				Expect(os.MkdirAll(filepath.Join(ctx.Application.Path, "META-INF"), 0755)).To(Succeed())
-				Expect(ioutil.WriteFile(
+				Expect(os.WriteFile(
 					filepath.Join(ctx.Application.Path, "META-INF", "MANIFEST.MF"),
 					[]byte(`Main-Class: test-main-class`),
 					0644,
@@ -242,7 +236,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 			it("marks all workspace files as group read-writable", func() {
 				Expect(os.MkdirAll(filepath.Join(ctx.Application.Path, "META-INF"), 0755)).To(Succeed())
-				Expect(ioutil.WriteFile(
+				Expect(os.WriteFile(
 					filepath.Join(ctx.Application.Path, "META-INF", "MANIFEST.MF"),
 					[]byte(`Main-Class: test-main-class`),
 					0644,
@@ -278,7 +272,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		context("native image", func() {
 			it("contributes classpath for build", func() {
 				Expect(os.MkdirAll(filepath.Join(ctx.Application.Path, "META-INF"), 0755)).To(Succeed())
-				Expect(ioutil.WriteFile(
+				Expect(os.WriteFile(
 					filepath.Join(ctx.Application.Path, "META-INF", "MANIFEST.MF"),
 					[]byte("Main-Class: test-main-class\nClass-Path: test-class-path"),
 					0644,
@@ -304,7 +298,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 	context("Manifest does not have Main-Class", func() {
 		it("return unmet jvm-application plan entry", func() {
 			Expect(os.MkdirAll(filepath.Join(ctx.Application.Path, "META-INF"), 0755)).To(Succeed())
-			Expect(ioutil.WriteFile(
+			Expect(os.WriteFile(
 				filepath.Join(ctx.Application.Path, "META-INF", "MANIFEST.MF"),
 				[]byte(`Class-Path: test-class-path`),
 				0644,

--- a/executable/classpath_test.go
+++ b/executable/classpath_test.go
@@ -17,7 +17,6 @@
 package executable_test
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -37,10 +36,7 @@ func testClassPath(t *testing.T, context spec.G, it spec.S) {
 	)
 
 	it.Before(func() {
-		var err error
-
-		ctx.Layers.Path, err = ioutil.TempDir("", "class-path-layers")
-		Expect(err).NotTo(HaveOccurred())
+		ctx.Layers.Path = t.TempDir()
 		contributor = executable.ClassPath{
 			ClassPath: []string{"test-value-1", "test-value-2"},
 		}

--- a/executable/detect_test.go
+++ b/executable/detect_test.go
@@ -17,7 +17,6 @@
 package executable_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -39,9 +38,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 	)
 
 	it.Before(func() {
-		var err error
-		path, err = ioutil.TempDir("", "executable-jar")
-		Expect(err).NotTo(HaveOccurred())
+		path = t.TempDir()
 
 		ctx.Application.Path = path
 	})
@@ -74,7 +71,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 	context("empty META-INF/MANIFEST.MF not found", func() {
 		it.Before(func() {
 			Expect(os.MkdirAll(filepath.Join(path, "META-INF"), 0755)).To(Succeed())
-			Expect(ioutil.WriteFile(
+			Expect(os.WriteFile(
 				filepath.Join(path, "META-INF", "MANIFEST.MF"),
 				[]byte(""),
 				0644,
@@ -104,7 +101,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 	context("META-INF/MANIFEST.MF with Main-Class", func() {
 		it.Before(func() {
 			Expect(os.MkdirAll(filepath.Join(path, "META-INF"), 0755)).To(Succeed())
-			Expect(ioutil.WriteFile(
+			Expect(os.WriteFile(
 				filepath.Join(path, "META-INF", "MANIFEST.MF"),
 				[]byte("Main-Class: test-main-class"),
 				0644,

--- a/executable/executable_jar_test.go
+++ b/executable/executable_jar_test.go
@@ -19,7 +19,6 @@ package executable_test
 import (
 	"archive/zip"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -36,10 +35,7 @@ func testManifest(t *testing.T, context spec.G, it spec.S) {
 	)
 
 	it.Before(func() {
-		var err error
-
-		appPath, err = ioutil.TempDir("", "manifest")
-		Expect(err).NotTo(HaveOccurred())
+		appPath = t.TempDir()
 	})
 
 	it.After(func() {
@@ -49,7 +45,7 @@ func testManifest(t *testing.T, context spec.G, it spec.S) {
 	context("exploded JAR", func() {
 		it("fail if not executable", func() {
 			Expect(os.MkdirAll(filepath.Join(appPath, "META-INF"), 0755)).To(Succeed())
-			Expect(ioutil.WriteFile(
+			Expect(os.WriteFile(
 				filepath.Join(appPath, "META-INF", "MANIFEST.MF"),
 				[]byte(`foo: bar`),
 				0644,
@@ -74,7 +70,7 @@ func testManifest(t *testing.T, context spec.G, it spec.S) {
 
 		it("loads executable JAR properties", func() {
 			Expect(os.MkdirAll(filepath.Join(appPath, "META-INF"), 0755)).To(Succeed())
-			Expect(ioutil.WriteFile(
+			Expect(os.WriteFile(
 				filepath.Join(appPath, "META-INF", "MANIFEST.MF"),
 				[]byte(`Main-Class: Foo`),
 				0644,


### PR DESCRIPTION
## Summary
When running `syft`, do not use effect.NewExecutor which runs the command with a tty. This seems to cause an issue with syft (or possibly with our tty library pty), and in either case you end up with stray formatting characters even though we tell syft to be quiet. Using CommandExecutor is basically the same, but it doesn't run with a tty.

This also removes usage of ioutil.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
